### PR TITLE
Minor FMJ fixes

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "icon": "assets/witherhearts/icon.png",
   "environment": "client",
-  "accesswidener": "witherhearts.accesswidener",
+  "accessWidener": "witherhearts.accesswidener",
   "entrypoints": {
     "client": [
       "net.ramixin.witherhearts.client.WitherHeartsClient"
@@ -25,7 +25,7 @@
   ],
   "depends": {
     "fabricloader": ">=${loader_version}",
-    "fabric": "*",
+    "fabric-api": "*",
     "minecraft": ">=1.21.2"
   }
 }


### PR DESCRIPTION
- `accessWidener` is typo'd as `accesswidener`, causing Fabric Loader to error reading it.
```
[17:35:01] [ForkJoinPool-1-worker-10/WARN]: The mod "witherhearts" contains invalid entries in its mod json:
- Unsupported root entry "accesswidener" at line 14 column 18
```
- Fabric API's namespace since 1.19.3 has been `fabric-api`, not `fabric`.